### PR TITLE
Fix build.properties file referencing files that do not exist.

### DIFF
--- a/AnyEditTools-feature/build.properties
+++ b/AnyEditTools-feature/build.properties
@@ -1,4 +1,1 @@
-bin.includes = feature.xml,\
-               about.ini,\
-               about.properties,\
-               loskutov32.png
+bin.includes = feature.xml


### PR DESCRIPTION
These files no longer exist in the feature:

* about.ini
* about.properties
* loskutoc32.png

This change removes the references to these files from build.properties.