### PR TITLE
change removeTrailingSpaces default to false for avoid unconscious mistakes

### DIFF
--- a/AnyEditTools/src/de/loskutov/anyedit/ui/preferences/AndyEditPreferenceInitializer.java
+++ b/AnyEditTools/src/de/loskutov/anyedit/ui/preferences/AndyEditPreferenceInitializer.java
@@ -47,7 +47,7 @@ AbstractPreferenceInitializer {
         store.setDefault(IAnyEditConstants.USE_REQUIRED_IN_PATH_CHARACTERS, true);
         store.setDefault(IAnyEditConstants.USE_JAVA_TAB_WIDTH_FOR_JAVA, true);
         store.setDefault(IAnyEditConstants.SAVE_DIRTY_BUFFER, true);
-        store.setDefault(IAnyEditConstants.REMOVE_TRAILING_SPACES, true);
+        store.setDefault(IAnyEditConstants.REMOVE_TRAILING_SPACES, false);
         store.setDefault(IAnyEditConstants.FIX_LINE_DELIMITERS, false);
         store.setDefault(IAnyEditConstants.SAVE_AND_FIX_LINE_DELIMITERS, false);
         store.setDefault(IAnyEditConstants.ADD_NEW_LINE, true);


### PR DESCRIPTION
ie: a developer try to fix a opensource project code bug which a tailingSpaces
he/she save the file in eclipse with anyedit plugin
By default removeTrailingSpaces=true, the will hard to diff and make  a pr

Do auto convert only if the  developer want(know) to do