### PR TITLE
Don't remove trailing whitespace from markdown

### DIFF
--- a/AnyEditTools/src/de/loskutov/anyedit/ui/preferences/AndyEditPreferenceInitializer.java
+++ b/AnyEditTools/src/de/loskutov/anyedit/ui/preferences/AndyEditPreferenceInitializer.java
@@ -60,7 +60,7 @@ AbstractPreferenceInitializer {
                 IAnyEditConstants.ACTION_ID_CONVERT_TABS);
         store.setDefault(IAnyEditConstants.REPLACE_ALL_TABS_WITH_SPACES, false);
         store.setDefault(IAnyEditConstants.REPLACE_ALL_SPACES_WITH_TABS, false);
-        store.setDefault(IAnyEditConstants.PREF_ACTIVE_FILTERS_LIST, "*.makefile,makefile,*.Makefile,Makefile,Makefile.*,*.mk,MANIFEST.MF,.project,*.yml");
+        store.setDefault(IAnyEditConstants.PREF_ACTIVE_FILTERS_LIST, "*.makefile,makefile,*.Makefile,Makefile,Makefile.*,*.mk,MANIFEST.MF,*.markdown,*.md,.project,*.yml");
         store.setDefault(IAnyEditConstants.PREF_INACTIVE_FILTERS_LIST, "");
         store.setDefault(IAnyEditConstants.ASK_BEFORE_CONVERT_ALL_IN_FOLDER, true);
         store.setDefault(IAnyEditConstants.INCLUDE_DERIVED_RESOURCES, false);


### PR DESCRIPTION
2 blanks at the end of a line render as linebreak, without starting a new paragraph. Therefore markdown file rendering would change when removing all trailing whitespace.

I haven't found any normative reference for that, but rather learned this from a colleague today. And that VS Code also did it wrong in the past: https://github.com/microsoft/vscode/issues/1679